### PR TITLE
update sane for watch-project support

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "devDependencies": {
     "broccoli": "^0.15.3",
     "mocha": "^2.0.1",
-    "rimraf": "^2.2.8",
-    "rsvp": "^3.0.14"
+    "rimraf": "^2.2.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "broccoli-slow-trees": "^1.1.0",
     "debug": "^2.1.0",
     "rsvp": "^3.0.14",
-    "sane": "^1.0.1"
+    "sane": "^1.1.0"
   },
   "devDependencies": {
     "broccoli": "^0.15.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "broccoli-slow-trees": "^1.1.0",
     "debug": "^2.1.0",
-    "rsvp": "^3.0.14",
+    "rsvp": "^3.0.18",
     "sane": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
With watchman 3.1 this will do magicks to dramatically dramatically reduce file-watchers. In an ideal scenario, (all ember-apps) it correctly only add s a root listener.

Although this does mean watchman must filter `tmp` related changes, in a 100kloc this didn't appear to cause major issues. And hopefully soon the `tmp` dir work will be complete, and entirely a non problem.