### PR TITLE
Provide extra arguments to the filter function

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ Watcher.prototype.addWatchDir = function Watcher_addWatchDir(dir) {
 
 function makeOnChanged (log) {
   return function (filePath, root) {
-    if (this.options.filter(path.basename(filePath))) {
+    if (this.options.filter(path.basename(filePath), filePath, root)) {
       if (this.options.verbose) console.log(log, filePath);
       this.scheduleBuild(path.join(root, filePath));
     }


### PR DESCRIPTION
provide extra arguments to the filter function. Useful to hide some
directories (tmp, dist or node_modules) from watcher. My broccoli-clext
plugin needs this to resolve problems reported by users.